### PR TITLE
Legislative district names now only show in popups if the districts are being displayed on the map

### DIFF
--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -271,7 +271,11 @@ the location of the click, with description HTML from its properties
 // generalised code to add district info
 function expandDistrictInfo(district) {
 // make sure we have a district to use
-if (district.length > 0 && district[0].layer.id === 'school_house_senate_districts_UNION-poly') {
+if (
+		(showHouseDistricts || showSenateDistricts) &&
+		district.length > 0 &&
+		district[0].layer.id === 'school_house_senate_districts_UNION-poly'
+	) {
 	data = district[0].properties;
 	var html = "";
 	html += "<span class='varname'>";


### PR DESCRIPTION
I think this resolves #8 .  Basically when I wrote the `expandDistrictInfo()` function I assumed that either House or Senate districts would always be shown, so never considered the possibility that neither is appropriate.  I've just added a check for that case.

One lingering effect that I'm not thrilled with is that some of the popups end up with a horizontal line as their last content, so I'm going to make a separate PR to sort that out.  That way you can compare results and see which you prefer.