### PR TITLE
Make the sidebar behave itself a bit better

### DIFF
--- a/css/cbf-programs-style.css
+++ b/css/cbf-programs-style.css
@@ -231,13 +231,14 @@ ul{
 }
 
 .console-content {
-  flex-grow: 1;
-  margin: 0px;
   background-color: white;
+  border-bottom: 2px solid #ccc;
+  flex: 1 0 auto;
+  margin: 0px;
+  padding: 10px 20px;
 }
 
 .console-item {
-  padding: 10px 20px;
 }
 
 .small-logo {

--- a/index.html
+++ b/index.html
@@ -66,24 +66,26 @@
 	<script src="scripts/onload.js"></script>
 
 	<div id="console">
-	  <div class="hide-for-small">
+	  <div class="console-content hide-for-small">
 		<a href="https://charlesbuttfdn.org/" target="_blank"><img class="style-logo" src="images/cbf_logo_curved_bottom.png" alt="Charles Butt Foundation logo"></a>
 	  </div>
-		<div id='legend' class='legend hide-for-small'>
+		<div id='legend' class='console-content legend hide-for-small'>
 			<div class="header">Toggle visibility</div>
-		<div class='legend-scale'>
-			<ul class='legend-labels'>
-				<li onClick="showHideLayer('charles-butt-scholars-points', markerNames=['charles_butt_scholars', 'charles_butt_scholars_icon']);" style="cursor: pointer;"><span id="charles_butt_scholars"></span>Charles Butt Scholars</li>
-				<li onClick="showHideLayer('raising-blended-learners-campuses-points', markerNames=['raising_blended_learners_campuses']);" style="cursor: pointer;"><span id="raising_blended_learners_campuses"></span>Raising Blended Learners (Districts)</li>
-				<li onClick="showHideLayer('raising-school-leaders-points', markerNames=['raising_school_leaders']);" style="cursor: pointer;"><span id="raising_school_leaders"></span>Raising School Leaders Participants</li>
-				<li onClick="showHideLayer('raising-texas-teachers-points', markerNames=['raising_texas_teachers', 'raising_texas_teachers_icon']);" style="cursor: pointer;"><span id="raising_texas_teachers"></span>Raising Texas Teachers:<br />(University Partners)</li>
-				<li id="school_districts_legend_entry" onClick="showHideLayer('state-school-districts-lines', markerNames=['state_school_districts']);" style="cursor: pointer !important;"><span id="state_school_districts" class="inactive"></span>State School Districts</li>
-				<li id="esc_legend_entry" onClick="showHideLayer('esc-regions-lines', markerNames=['esc_regions']);" style="cursor: pointer !important;"><span id="esc_regions" class="inactive"></span>Education Service Centers</li>
-			</ul>
-		</div> <!-- end of div class='legend-scale' -->
+			<div class='legend-scale'>
+				<ul class='legend-labels'>
+					<li onClick="showHideLayer('charles-butt-scholars-points', markerNames=['charles_butt_scholars', 'charles_butt_scholars_icon']);" style="cursor: pointer;"><span id="charles_butt_scholars"></span>Charles Butt Scholars</li>
+					<li onClick="showHideLayer('raising-blended-learners-campuses-points', markerNames=['raising_blended_learners_campuses']);" style="cursor: pointer;"><span id="raising_blended_learners_campuses"></span>Raising Blended Learners (Districts)</li>
+					<li onClick="showHideLayer('raising-school-leaders-points', markerNames=['raising_school_leaders']);" style="cursor: pointer;"><span id="raising_school_leaders"></span>Raising School Leaders Participants</li>
+					<li onClick="showHideLayer('raising-texas-teachers-points', markerNames=['raising_texas_teachers', 'raising_texas_teachers_icon']);" style="cursor: pointer;"><span id="raising_texas_teachers"></span>Raising Texas Teachers:<br />(University Partners)</li>
+					<li id="school_districts_legend_entry" onClick="showHideLayer('state-school-districts-lines', markerNames=['state_school_districts']);" style="cursor: pointer !important;"><span id="state_school_districts" class="inactive"></span>State School Districts</li>
+					<li id="esc_legend_entry" onClick="showHideLayer('esc-regions-lines', markerNames=['esc_regions']);" style="cursor: pointer !important;"><span id="esc_regions" class="inactive"></span>Education Service Centers</li>
+				</ul>
+			</div> <!-- end of div class='legend-scale' -->
+		</div> <!-- end of div id="legend" -->
 
-			<div class="header-dropdown">
-			Zoom in and out
+		<div class="console-content">
+			<div class="header">
+				Zoom in and out
 			</div>
 
 			<!--Drop down controls-->
@@ -140,8 +142,8 @@
 				<input type="radio" checked="true">
 					<span class="checkmark"></span>Texas <b>School</b> Districts.
 			</p>
-
-
+		</div>
+		<div class="console-content">
 			<p class="header-explore">
 				Explore the reach of our programs across the state</p>
 
@@ -156,10 +158,12 @@
 				<span id='slider_stop' onclick="stopYearAnimation('slider_play', 'slider_stop');" title='Stop animation'><img src="images/stop.svg"></span>
 				<span id='slider_forward' onclick="moveYearSlider('active-year', 1);" title='Go forward one year'><img src="images/skip_forward.svg"></span>
 			</div> <!-- id='slidercontrols' -->
-
+		</div>
+		<div class="console-content">
 			<div class='map-credit'>Source: <a href="https://charlesbuttfdn.org/" target="_blank">Charles Butt Foundation</a></div>
 			<div class='map-credit'>Map design by <a href="http://www.coregis.net/" target="_blank">CORE GIS</a></div>
-		</div> <!-- end of div id="legend" -->
+		</div>
+	</div> <!-- end of console div -->
 
 	<!--END FLYOUT FOR 'CONSOLE'-->
 


### PR DESCRIPTION
I'm going to isolate this little bit into a PR so you can see how close you were to getting this to do what you want!

What I did here has to do with the way that `display: flex` works. What that does is it lays out the _immediate children_ of the thing that's set to `display: flex` very neatly. So in order to get that in the sidebar, here's what I did:

- put the sections that needed to lay themselves out in the sidebar into their own divs, so that the div that has `id="console` now has children that are `class="console-content`
- closed the `legend` div earlier to help with that
- gave `console-content` a `flex: 1 0 auto`. What this does is it tells each child of `console`, with its `flex` layout, to grow to fit available space (1), to *not* shrink if the sidebar is not long enough to fit everything so it will scroll instead (0), and to size everything roughly according to its contents.
- added some padding on everything to make it look nicer, since putting things in their own divs blew away the padding on them

I put the borders on the divs after that like they appear in the Figma file, just because putting the sections in their own divs made that easy.

This won't 'stick' your footer to the bottom yet but the content in this sidebar is tall enough that this might not matter - let me know if you'd like me to stick the footer at the bottom.

I can get this closer to looking like the Figma file if you'd like, by styling the dropdowns and scootching some things around, just let me know if you'd like that. I'll try and find where `RHYT` showed up next, though.