### PR TITLE
Stats box fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 
 		<div class='stats' id='statsBox'>
 			<div class='stats-title'>
-				Active Programs in
+				Programs in
 				<br />
 				<span class="select" id="stats.districtType"></span> <span class="select" id="stats.districtName"></span> <span class="select" id="stats.districtSuffix"></span>
 				<br />

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
 				<br />
 				<span class="select" id="stats.districtType"></span> <span class="select" id="stats.districtName"></span> <span class="select" id="stats.districtSuffix"></span>
 				<br />
-				In <span class="select" id="stats.year"></span>
+				By <span class="select" id="stats.year"></span>
 			</div>
 			<div class='stats-scale'>
 				<ul class='stats-labels'>

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -535,15 +535,10 @@ function updateStatsBox() {
 		}
 		document.getElementById("stats.year").innerText = filterStates.year;
 		for (let i in loadedPointLayers) {
-			if (loadedPointLayers[i][0].includes("raising-blended-learners")) {
-				f = ['<', 'year', (filterStates.year + 4).toString()];
-			} else {
-				f = ['==', 'year', filterStates.year.toString()];
-			}
 			pointsInDistrict = getUniqueFeatures(
 				map.queryRenderedFeatures( {
 					layers: [loadedPointLayers[i][0]],
-					filter: f
+					filter: ['<=', 'year', filterStates.year.toString()]
 				} ),
 				"unique_id"
 			);

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -304,7 +304,7 @@ map.on('mouseleave', 'raising-blended-learners-campuses-points', function () {
 	map.getCanvas().style.cursor = '';
 });
 
-map.on('zoomend', function() { updateStatsBox(); });
+map.on('idle', function() { updateStatsBox(); });
 
 function fillpopup_rbl(features){
 	let html = "";


### PR DESCRIPTION
Resolves #27 

1. Now shows cumulative stats _up to_ the selected year, instead of only programs that are new in that year, at Kurt's request.
2. I switched the event that triggers a redraw of the stats box from [zoomend](https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:zoomend) to [idle](https://docs.mapbox.com/mapbox-gl-js/api/map/#map.event:idle), which seems to have fixed some glitches I'd been noticing where the stats box was failing to update after a filter finished applying.