### PR TITLE
If there are multiple coordinate fields, use the first

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -918,6 +918,8 @@ function compileUniqueArray(features, ignoreFields = []) {
 
 function normaliseHeaders(row, delimiter) {
 	let headers = row.split(delimiter);
+	let xfield = false;
+	let yfield = false;
 	for (let i in headers) {
 		switch (headers[i].toLowerCase()) {
 			case "longitude":
@@ -926,13 +928,19 @@ function normaliseHeaders(row, delimiter) {
 			case "lon":
 			case "x":
 			case "xcoord":
-				headers[i] = "x";
+				if (not xfield) {
+					headers[i] = "x";
+					xfield = true;
+				}
 				break;
 			case "latitude":
 			case "lat":
 			case "y":
 			case "ycoord":
-				headers[i] = "y";
+				if (not yfield) {
+					headers[i] = "y";
+					yfield;
+				}
 		}
 	}
 	return headers;

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -928,7 +928,7 @@ function normaliseHeaders(row, delimiter) {
 			case "lon":
 			case "x":
 			case "xcoord":
-				if (not xfield) {
+				if (!xfield) {
 					headers[i] = "x";
 					xfield = true;
 				}
@@ -937,7 +937,7 @@ function normaliseHeaders(row, delimiter) {
 			case "lat":
 			case "y":
 			case "ycoord":
-				if (not yfield) {
+				if (!yfield) {
 					headers[i] = "y";
 					yfield;
 				}

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -931,6 +931,8 @@ function normaliseHeaders(row, delimiter) {
 				if (!xfield) {
 					headers[i] = "x";
 					xfield = true;
+				} else {
+					console.log("Caution: multiple potential X coordinate fields:", row)
 				}
 				break;
 			case "latitude":
@@ -939,7 +941,9 @@ function normaliseHeaders(row, delimiter) {
 			case "ycoord":
 				if (!yfield) {
 					headers[i] = "y";
-					yfield;
+					yfield = true;
+				} else {
+					console.log("Caution: multiple potential Y coordinate fields:", row)
 				}
 		}
 	}


### PR DESCRIPTION
This should fix the bug reported by @cbfdn-kwang today, and does when I test it locally.  Background:

@cbfdn-kwang reported that the Charles Butt Scholars layer wasn't showing up.  Looking at requests in the JS console I see that the data are being received from Google Drive, and there are no error messages.  

The issue seems to be that my `normaliseHeaders()` function, which identifies which fields to use for x and y coordinates, didn't do anything sensible when a data source contained multiple potential fields.  The relevant sheet had `longitude,latitude` as its first two columns, but in demoing the geocoding function a couple of weeks ago we had added `lat,long` as the last two, but left them blank.  That in turn was leading my code to use the blank columns and have no coordinates to place the Charles Butt Scholars points at.  They're probably all at Null Island, but because we set limits on scrolling the map I couldn't check that.

As a quick fix, I have deleted the `lat` and `long` columns from the Charles Butt Scholars sheet, which has restored the layer visually.  But adding those columns is a routine part of the geocoding process, and leaving the headers in there shouldn't break anything!  Meanwhile we do have a pretty strong convention of putting the real coordinates first in these files.  So to prevent a recurrence of this problem, this PR simply makes `normaliseHeaders()` use the first potential X and Y columns it finds and ignore others.